### PR TITLE
Add missing space

### DIFF
--- a/common/recipes-core/fan-ctrl/fan-ctrl/fand.cpp
+++ b/common/recipes-core/fan-ctrl/fan-ctrl/fand.cpp
@@ -1306,7 +1306,7 @@ int main(int argc, char **argv) {
     if (log_count++ % report_temp == 0) {
       syslog(LOG_DEBUG,
              "Temp chipset %f, CPU1 %f, CPU2 %f, "
-             "CPU fan speed %d, CPU speed changes %d"
+             "CPU fan speed %d, CPU speed changes %d "
              "chassis fan speed %d, chassis speed changes %d",
              EXTERNAL_TEMPS((float)chipset_temp),
              EXTERNAL_TEMPS((float)cpu1_temp),


### PR DESCRIPTION
Right now, `fand` produces messages like:
```
Sep  7 11:53:31 bmc daemon.debug fand: Temp chipset 50.000000, CPU1 57.250000, CPU2 39.750000, CPU fan speed 45, CPU speed changes 2469chassis fan speed 35, chassis speed changes 2336
```

There's no space before "chassis".